### PR TITLE
Add conservative Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,21 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-major"
+
+  - package-ecosystem: "npm"
+    directory: "/functions"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-major"


### PR DESCRIPTION
## Summary
- Add Dependabot for npm dependencies in the root package.
- Add Dependabot for npm dependencies in functions/.
- Limit update PRs to 5 per ecosystem and ignore major version updates.

## Omitted
- GitHub Actions updates, because this repository did not have existing workflows when this branch was created.
- pnpm, yarn, bun, Docker, and other ecosystems not present in versioned project files.

## Validation
- Parsed .github/dependabot.yml with Ruby YAML.
- Ran git diff --cached --check before committing.