### PR TITLE
Add minimal CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,34 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: |
+            package-lock.json
+            functions/package-lock.json
+
+      - name: Install root dependencies
+        run: npm ci
+
+      - name: Install functions dependencies
+        run: npm ci --prefix functions
+
+      - name: Build
+        run: npm run build


### PR DESCRIPTION
## Summary
- Add a minimal GitHub Actions CI workflow for pull requests and pushes to main.
- Use Node 20, npm ci for the root app, npm ci for functions/, and npm run build.

## Omitted
- Lint is omitted because npm run lint currently fails on existing lint errors.
- Tests are omitted because npm test -- --run currently fails without the Firestore emulator on localhost:8080.
- No secrets, environment variables, Vercel deploy settings, or application logic were changed.

## Validation
- npm ci
- npm ci --prefix functions (passes with the existing Node 22 engine warning under local Node 20)
- npm run build
- Parsed .github/workflows/ci.yml with Ruby YAML.
- Ran git diff --cached --check before committing.